### PR TITLE
TTL and Caching

### DIFF
--- a/source/input-validate/index.js
+++ b/source/input-validate/index.js
@@ -43,7 +43,8 @@ exports.handler = async (event) => {
       enableSqs: JSON.parse(process.env.EnableSqs),
       geoRestriction: event.geoRestriction,
       cmsId: event.cmsId,
-      cmsCommandId: event.cmsCommandId
+      cmsCommandId: event.cmsCommandId,
+      ttl: event.ttl
     };
 
     switch (event.workflowTrigger) {

--- a/source/output-validate/lib/index.spec.js
+++ b/source/output-validate/lib/index.spec.js
@@ -12,10 +12,13 @@
  *********************************************************************************************************************/
 
 const chai = require('chai');
+const spies = require('chai-spies');
 const assertArrays = require('chai-arrays');
-chai.use(assertArrays);
+chai.use(assertArrays).use(spies);
 
 const expect = chai.expect;
+const spy = chai.spy;
+
 const path = require('path');
 const AWS = require('aws-sdk-mock');
 AWS.setSDK(path.resolve('./node_modules/aws-sdk'));
@@ -40,19 +43,9 @@ describe('#OUTPUT VALIDATE::', () => {
   const data = {
     Item: {
       guid: '1234',
-      cloudFront: 'cloudfront',
-      destBucket: 'vod-destination',
-      frameCapture: false
-    }
-  };
-
-  const img_data = {
-    Item: {
-      guid: '1234',
-      cloudFront: 'cloudfront',
-      destBucket: 'vod-destination',
-      srcVideo: 'directory/file.mp4',
-      frameCapture: true
+      frameCapture: false,
+      srcBucket: 'vod-source',
+      srcVideo: '/folder/file.mp4'
     }
   };
 
@@ -63,13 +56,18 @@ describe('#OUTPUT VALIDATE::', () => {
     ]
   }
 
+  process.env.AWS_REGION = 'us-east-1';
   process.env.ErrorHandler = 'error_handler';
+  process.env.Destination = 'vod-destination';
+  process.env.CloudFront = 'cloudfront';
 
   afterEach(() => AWS.restore('DynamoDB.DocumentClient'));
   afterEach(() => AWS.restore('S3'));
 
   it('should return "SUCCESS" on parsing CMAF MSS output', async () => {
     AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(data));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve({Contents: []}));
+    AWS.mock('S3', 'headObject', Promise.resolve({Metadata: {}}));
 
     const response = await lambda.handler(_events.cmafMss);
     expect(response.mssPlaylist).to.equal('s3://vod-destination/12345/mss/big_bunny.ism');
@@ -80,6 +78,8 @@ describe('#OUTPUT VALIDATE::', () => {
 
   it('should return "SUCCESS" on parsing HLS DASH output', async () => {
     AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(data));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve({Contents: []}));
+    AWS.mock('S3', 'headObject', Promise.resolve({Metadata: {}}));
 
     const response = await lambda.handler(_events.hlsDash);
     expect(response.hlsPlaylist).to.equal('s3://vod-destination/12345/hls/dude.m3u8');
@@ -90,6 +90,8 @@ describe('#OUTPUT VALIDATE::', () => {
 
   it('should return "SUCCESS" on parsing MP4 output', async () => {
     AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(data));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve({Contents: []}));
+    AWS.mock('S3', 'headObject', Promise.resolve({Metadata: {}}));
 
     const response = await lambda.handler(_events.mp4);
     expect(response.mp4Outputs[0]).to.equal('s3://vod-destination/12345/mp4/dude_3.0Mbps.mp4');
@@ -107,6 +109,8 @@ describe('#OUTPUT VALIDATE::', () => {
 
   it('should return "ERROR" when output parse fails', async () => {
     AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(data));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve({Contents: []}));
+    AWS.mock('S3', 'headObject', Promise.resolve({Metadata: {}}));
 
     await lambda.handler(_error).catch(err => {
       expect(err.toString()).to.equal('Could not parse MediaConvert Output');
@@ -114,12 +118,42 @@ describe('#OUTPUT VALIDATE::', () => {
   });
 
   it('should return frame capture data', async () => {
-    AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(img_data));
-    AWS.mock('S3', 'listObjects', Promise.resolve(s3_list_response));
+    const dataWithFrameCapture = {Item: {...data.Item, frameCapture: true}};
+    AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(dataWithFrameCapture));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve(s3_list_response));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve({Contents: []}));
+    AWS.mock('S3', 'headObject', Promise.resolve({Metadata: {}}));
+    AWS.mock('S3', 'copyObject', Promise.resolve());
 
     const response = await lambda.handler(_events.mp4);
     expect(response.thumbNailsUrls).to.be.containing('https://cloudfront/12345/thumbnails/dude3.001.jpg');
     expect(response.thumbNails).to.be.containing('s3://vod-destination/12345/thumbnails/dude3.001.jpg');
+  });
+
+  it('set cache-control-headers on the output files', async () => {
+    const doCopy = (params, callback) => {
+      callback(null, {});
+    }
+    const s3CopySpy = spy(doCopy);
+
+    AWS.mock('DynamoDB.DocumentClient', 'get', Promise.resolve(data));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve(s3_list_response));
+    AWS.mock('S3', 'listObjectsV2', Promise.resolve({Contents: []}));
+    AWS.mock('S3', 'headObject', Promise.resolve({Metadata: {'CacheControl': 'max-age=123456,public'}}));
+    AWS.mock('S3', 'copyObject', s3CopySpy);
+
+    await lambda.handler(_events.mp4);
+
+    expect(s3CopySpy).to.have.been.called.with({
+      "Bucket": "vod-destination",
+      "ContentType": "image/jpeg",
+      "CopySource": "vod-destination/12345/thumbnails/dude3.000.jpg",
+      "Key": "12345/thumbnails/dude3.000.jpg",
+      "Metadata": {
+        "CacheControl": "max-age=123456,public"
+      },
+      "MetadataDirective": "REPLACE"
+    });
   });
 });
 

--- a/source/output-validate/package-lock.json
+++ b/source/output-validate/package-lock.json
@@ -282,6 +282,12 @@
       "integrity": "sha512-4awrdGI2EH8owJ9I58PXwG4N56/FiM8bsn4CVSNEgr4GKAM6Kq5JPVApUbhUBjDakbZNuRvV7quRSC38PWq/tg==",
       "dev": true
     },
+    "chai-spies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
+      "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/source/output-validate/package.json
+++ b/source/output-validate/package.json
@@ -19,6 +19,7 @@
     "aws-sdk-mock": "^5.0.0",
     "chai": "4.3.4",
     "chai-arrays": "2.2.0",
+    "chai-spies": "^1.0.0",
     "mocha": "^7.0.0",
     "sinon": "^8.1.1"
   },

--- a/source/step-functions/index.js
+++ b/source/step-functions/index.js
@@ -65,6 +65,7 @@ exports.handler = async (event) => {
           if (metadata.hasOwnProperty("cms-id")) event.cmsId = metadata["cms-id"];
           if (metadata.hasOwnProperty("geo-restriction")) event.geoRestriction = metadata["geo-restriction"];
           if (metadata.hasOwnProperty("command-id")) event.cmsCommandId = metadata["command-id"];
+          if (metadata.hasOwnProperty("ttl")) event.ttl = parseInt(metadata["ttl"], 10);
         }
         event.guid = event.cmsCommandId || uuidv4();
         if (event.cmsCommandId) {


### PR DESCRIPTION
- `λ_step_functions`: get `ttl` from s3-meta and add it to the event. the field `ttl` then gets persisted to the ddb
- `λ_output_validate`: copy the original `CacheControl`/`Expires` from the source file to all the generated files (m3u8,ts,jpg)
